### PR TITLE
Fixed section 2.3, exercise 7

### DIFF
--- a/content/02-linear-reg/extension-limitation.ipynb
+++ b/content/02-linear-reg/extension-limitation.ipynb
@@ -1083,7 +1083,7 @@
     "boston_df[\"resid1\"] = boston_df.crim - boston_df.pred1\n",
     "\n",
     "\n",
-    "boston_df[\"ptratio2\"] = boston_df.nox**3\n",
+    "boston_df[\"ptratio2\"] = boston_df.ptratio**2\n",
     "# Quadratic fit\n",
     "X2 = boston_df[[\"ptratio\", \"ptratio2\"]].values\n",
     "regr.fit(X2, y)\n",

--- a/content/index.md
+++ b/content/index.md
@@ -70,7 +70,7 @@ Besides the prerequisites, the 10 chapters can be grouped into two parts: part o
 <table>
   <tbody>
     <tr>
-      <td align="center"><a href="https://haipinglu.github.io/"><img src="https://raw.githubusercontent.com/haipinglu/hugo-academic/main/content/authors/haiping-lu/avatar.png" width="200px;" alt="Haiping Lu"/><br /><sub><b>Haiping Lu</b></sub></a></td>
+      <td align="center"><a href="https://haipinglu.github.io/"><img src="https://raw.githubusercontent.com/haipinglu/hugo-academic/main/content/authors/haiping-lu/avatar.jpg" width="200px;" alt="Haiping Lu"/><br /><sub><b>Haiping Lu</b></sub></a></td>
       <td align="center"><a href="https://shuo-zhou.github.io/"><img src="https://raw.githubusercontent.com/shuo-zhou/shuo-zhou.github.io/master/assets/img/profile.png" width="200px;" alt="Shuo Zhou"/><br /><sub><b>Shuo Zhou</b></sub></a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Fixed the error in section 2.3, exercise 7, where instead of regressing "ptratio" onto "crim", we mistakenly used "nox" onto "crim". Also, instead of using a quadratic term, we used a cubic term.

Previously:
boston_df["ptratio2"] = boston_df.nox**3

This has been corrected to:

boston_df["ptratio2"] = boston_df.ptratio**2


Thanks to @eraunio for bringing this to our attention in discussion #53.